### PR TITLE
Add model decryption to model_archiver and add MAR decompression and decryption to Backend.

### DIFF
--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/utils/ArchiveUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/utils/ArchiveUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import java.io.File;
+import java.io.InputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -33,6 +34,15 @@ public final class ArchiveUtils {
         try (Reader r =
                 new InputStreamReader(
                         Files.newInputStream(file.toPath()), StandardCharsets.UTF_8)) {
+            return GSON.fromJson(r, type);
+        } catch (JsonParseException e) {
+            throw new InvalidModelException("Failed to parse signature.json.", e);
+        }
+    }
+
+    public static <T> T readInputStream(InputStream is, Class<T> type)
+            throws InvalidModelException, IOException {
+        try (Reader r = new InputStreamReader(is)) {
             return GSON.fromJson(r, type);
         } catch (JsonParseException e) {
             throw new InvalidModelException("Failed to parse signature.json.", e);

--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -152,13 +152,28 @@ class ArgParser(object):
         )
 
         parser_export.add_argument(
-            "--key-store",
+            "--encryption-key",
             required=False,
             type=str,
             default=None,
-            help="Path to key",
+            help="Path to key for encrypting MAR",
         )
 
+        parser_export.add_argument(
+            "--decryption-key",
+            required=False,
+            type=str,
+            default=None,
+            help="Path to key for decrypting model and other files",
+        )
 
+        parser_export.add_argument(
+            "--encrypted-files",
+            required=False,
+            type=str,
+            default=None,
+            help="Encrypted files that need to be decrypted by fernet with decryption-key",
+        )
 
         return parser_export
+

--- a/model-archiver/model_archiver/model_packaging.py
+++ b/model-archiver/model_archiver/model_packaging.py
@@ -22,6 +22,7 @@ def package_model(args, manifest):
     extra_files = args.extra_files
     export_file_path = args.export_path
     requirements_file = args.requirements_file
+    encrypted_files = args.encrypted_files
 
     try:
         ModelExportUtils.validate_inputs(model_name, export_file_path)
@@ -37,14 +38,20 @@ def package_model(args, manifest):
             "handler": handler,
             "extra_files": extra_files,
             "requirements-file": requirements_file,
+            "encrypted_files": encrypted_files,
         }
 
         model_path = ModelExportUtils.copy_artifacts(model_name, **artifact_files)
 
         # Step 2 : Zip 'em all up
-        ModelExportUtils.archive(
-            export_file_path, model_name, model_path, manifest, args.archive_format, args.model_encryption, args.key_store
-        )
+        ModelExportUtils.archive(export_file_path,
+                                 model_name,
+                                 model_path,
+                                 manifest,
+                                 args.archive_format,
+                                 model_encryption=args.model_encryption,
+                                 encryption_key=args.encryption_key,
+                                 decryption_key=args.decryption_key)
         shutil.rmtree(model_path)
         logging.info(
             "Successfully exported model %s to file %s", model_name, export_file_path
@@ -68,3 +75,4 @@ def generate_model_archive():
 
 if __name__ == "__main__":
     generate_model_archive()
+

--- a/ts/arg_parser.py
+++ b/ts/arg_parser.py
@@ -149,6 +149,27 @@ class ArgParser(object):
             help="Model name.",
         )
 
+        parser.add_argument(
+            "--model-file",
+            dest="model_file",
+            type=str,
+            help="Path to the model file.",
+        )
+
+        parser.add_argument(
+            "-d",
+            "--model-decryption",
+            dest="model_decryption",
+            action="store_true",
+            help="Whether the model needs to be decrypted.",
+        )
+
+        parser.add_argument(
+            "--decryption-key",
+            dest="decryption_key",
+            type=str,
+            help="Path to the key for decrypting MAR.",
+        )
 
         return parser
 
@@ -156,3 +177,4 @@ class ArgParser(object):
     def extract_args(args=None):
         parser = ArgParser.ts_parser()
         return parser.parse_args(args) if args else parser.parse_args()
+

--- a/ts/model_service_worker.py
+++ b/ts/model_service_worker.py
@@ -12,6 +12,12 @@ import socket
 import sys
 import uuid
 import time
+import io
+import zipfile
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import padding
 
 from ts.arg_parser import ArgParser
 from ts.metrics.metric_cache_yaml_impl import MetricsCacheYamlImpl
@@ -38,8 +44,22 @@ class TorchModelServiceWorker(object):
         host_addr=None,
         port_num=None,
         metrics_config=None,
+        frontend_ip=None,
+        frontend_port=None,
+        model_name=None,
+        model_file=None,
+        model_decryption=False,
+        decryption_key=None,
     ):
         self.sock_type = s_type
+        self.host = host_addr
+        self.port = port_num
+        self.frontend_ip = frontend_ip
+        self.frontend_port = frontend_port
+        self.model_name = model_name
+        self.model_file = model_file
+        self.model_decryption = model_decryption
+        self.decryption_key = decryption_key
 
         if s_type == "unix":
             if s_name is None:
@@ -88,7 +108,7 @@ class TorchModelServiceWorker(object):
         :return:
         """
         try:
-            model_dir = load_model_request["modelPath"].decode("utf-8")
+            #model_dir = load_model_request["modelPath"].decode("utf-8")
             model_name = load_model_request["modelName"].decode("utf-8")
             handler = (
                 load_model_request["handler"].decode("utf-8")
@@ -114,6 +134,28 @@ class TorchModelServiceWorker(object):
             limit_max_image_pixels = True
             if "limitMaxImagePixels" in load_model_request:
                 limit_max_image_pixels = bool(load_model_request["limitMaxImagePixels"])
+
+            with open(self.model_file, 'rb') as model_file:
+                model = io.BytesIO(model_file.read())
+
+            if self.model_decryption:
+                with open(self.decryption_key, 'rb') as key_file:
+                    key = key_file.read()
+                model = model.getvalue()
+                cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+                decryptor = cipher.decryptor()
+                unpadder = padding.PKCS7(128).unpadder()
+                unpadded_data = unpadder.update(decryptor.update(model) + decryptor.finalize()) + unpadder.finalize()
+
+                model = io.BytesIO(unpadded_data)
+
+            model_dir = {}
+            with zipfile.ZipFile(model, 'r') as model_zip:
+                file_list = model_zip.namelist()
+                print(file_list)
+                for file_name in file_list:
+                    with model_zip.open(file_name) as file:
+                        model_dir[file_name] = io.BytesIO(file.read())
 
             self.metrics_cache.model_name = model_name
             model_loader = ModelLoaderFactory.get_model_loader()
@@ -185,10 +227,10 @@ class TorchModelServiceWorker(object):
             import requests
             while True:
                 try:
-                    url = "http://" + frontend_ip + ":" + frontend_port + "/models/" + model_name + "?IP=" + host + "&PORT=" + port
+                    url = "http://" + self.frontend_ip + ":" + self.frontend_port + "/models/" + self.model_name + "?IP=" + self.host + "&PORT=" + self.port
                     response = requests.put(url)
                     if response.status_code < 200 or response.status_code >=300:
-                        url = "https://" + frontend_ip + ":" + frontend_port + "/models/" + model_name + "?IP=" + host + "&PORT=" + port
+                        url = "https://" + self.frontend_ip + ":" + self.frontend_port + "/models/" + self.model_name + "?IP=" + self.host + "&PORT=" + self.port
                         response = requests.put(url, verify=False)
                     break
                 except requests.exceptions.ConnectionError as e:
@@ -225,6 +267,9 @@ if __name__ == "__main__":
         frontend_ip = args.frontend_ip
         frontend_port = args.frontend_port
         model_name = args.model_name
+        model_file = args.model_file
+        model_decryption = args.model_decryption
+        decryption_key = args.decryption_key
 
 
         if BENCHMARK:
@@ -234,9 +279,17 @@ if __name__ == "__main__":
             pr.disable()
             pr.dump_stats("/tmp/tsPythonProfile.prof")
 
-        worker = TorchModelServiceWorker(
-            sock_type, socket_name, host, port, metrics_config
-        )
+        worker = TorchModelServiceWorker(sock_type,
+                                         socket_name,
+                                         host,
+                                         port,
+                                         metrics_config,
+                                         frontend_ip,
+                                         frontend_port,
+                                         model_name,
+                                         model_file,
+                                         model_decryption,
+                                         decryption_key)
         worker.run_server()
         if BENCHMARK:
             pr.disable()


### PR DESCRIPTION
## Description

Now we accept model file encrypted by fernet and decrypt it in model_archiver. Plain text will be saved to IO instead of files on disk.
Add --decryption-key to assign decryption key for fernet.
Add --encrypted-files to tell model_archiver the files that should be decrypted.

Then, files will be compressed and encrypted by AES.

When the model is served by Torchserve, the frontend will get the MANIFEST file from MAR to config the model attributes. Backends will decompress MAR and save the files to IO